### PR TITLE
upgrade mcm-813x9 to v0.34.0

### DIFF
--- a/public/mcm-81339-v0-33-0.bin
+++ b/public/mcm-81339-v0-33-0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:066d22cf93916dc55bb0ca706bc28d9f792dfecc86d2496d9eff4ed5379dbd71
-size 1783312

--- a/public/mcm-81339-v0-34-0.bin
+++ b/public/mcm-81339-v0-34-0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11c4e60f6af1e17556df2259947d9f1db08aa9f5b33ba04b261d59c1c652b29c
+size 1783088

--- a/public/mcm-81349-v0-33-0.bin
+++ b/public/mcm-81349-v0-33-0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:204bac3f8094a586f40851ba3f26e77330456ab3a06ac38f874c9a934c6fc7e5
-size 1783360

--- a/public/mcm-81349-v0-34-0.bin
+++ b/public/mcm-81349-v0-34-0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a13a1cee91a5a501c1b02f53719890d020fe1cdf59857d333fe3b764b32e1f
+size 1783152

--- a/src/views/system/SystemUpgrade.vue
+++ b/src/views/system/SystemUpgrade.vue
@@ -23,8 +23,8 @@ const firmwareBaseNames = {
   'Melexis Compact Master LIN': 'mcm-lin',
 };
 const firmwareLatestRev = {
-  'mcm-81339': 'v0.33.0',
-  'mcm-81349': 'v0.33.0',
+  'mcm-81339': 'v0.34.0',
+  'mcm-81349': 'v0.34.0',
   'mcm-lin': 'v0.5.0',
 };
 let firmwareBaseName = '';


### PR DESCRIPTION
upgrade mcm-813x9 to v0.34.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated firmware version targets for Melexis Compact Master device builds (mcm-81339, mcm-81349) to v0.34.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->