### PR TITLE
Upgrade mcm-813x9 to v0.36.0

### DIFF
--- a/public/mcm-81339-v0-35-0.bin
+++ b/public/mcm-81339-v0-35-0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7ba556584508a7c901f32821dbed6bf8aeced71d94e07b6409a5334298335c9
-size 1792384

--- a/public/mcm-81339-v0-36-0.bin
+++ b/public/mcm-81339-v0-36-0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc65e8fb8987bf3b1b6c7bd81f83e6ece0f877edde7bca336f11b712d7c31b73
+size 1794784

--- a/public/mcm-81349-v0-35-0.bin
+++ b/public/mcm-81349-v0-35-0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54674141efd35fcd478e556d5f8da3885cddc47b005f49a7fa2ea2013a217b3c
-size 1792224

--- a/public/mcm-81349-v0-36-0.bin
+++ b/public/mcm-81349-v0-36-0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:595b3ba74e9fc8314d81cbd5b7d483ea08708d46337dc12ddb045e54f11477a8
+size 1794608

--- a/src/views/system/SystemUpgrade.vue
+++ b/src/views/system/SystemUpgrade.vue
@@ -23,8 +23,8 @@ const firmwareBaseNames = {
   'Melexis Compact Master LIN': 'mcm-lin',
 };
 const firmwareLatestRev = {
-  'mcm-81339': 'v0.35.0',
-  'mcm-81349': 'v0.35.0',
+  'mcm-81339': 'v0.36.0',
+  'mcm-81349': 'v0.36.0',
   'mcm-lin': 'v0.5.0',
 };
 let firmwareBaseName = '';


### PR DESCRIPTION
Upgrade mcm-813x9 to v0.36.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the latest available firmware version for Melexis Compact Master models mcm-81339 and mcm-81349 from v0.35.0 to v0.36.0. This ensures the system correctly identifies available firmware upgrades and displays the appropriate target revision for these hardware models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->